### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@ Types of schedules supported by _Schedule_:
 * Manage elevator reservations for an apartment building
 * Schedule the company ping pong tournment
 
-####For complete documentation visit [http://bunkat.github.io/schedule/](http://bunkat.github.io/schedule/).
+#### For complete documentation visit [http://bunkat.github.io/schedule/](http://bunkat.github.io/schedule/).
 
 
 ## Installation


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
